### PR TITLE
Activate unbuffered output for Python

### DIFF
--- a/Dockerfile-0.12.5
+++ b/Dockerfile-0.12.5
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
 
+ENV PYTHONUNBUFFERED=1
+
 RUN set -x \
   && apt update \
   && apt -y install --no-install-recommends wget ca-certificates \


### PR DESCRIPTION
The amount of output is low and the output is buffered for too long.
Activating the unbuffering makes Python output the logs directly.