### PR TITLE
[IMP] client to return mocked server version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ There are two clients:
 * a python client, which only depends on the `requests` library.
   It should work with any python version supported by `requests`.
 
+### mock server
+
+Odoo [checks for `wkhtmltopdf`'s version on start](https://github.com/odoo/odoo/blob/12.0/odoo/addons/base/models/ir_actions_report.py#L58).
+
+In a CI context, we don't necessarily want to run the `kwkhtmtopdf` container.
+But we definitely want Odoo to start.
+
+To support this case, you can set `KWKHTMLTOPDF_SERVER_URL=MOCK`: the client will
+then return `wkhtmltopdf 0.12.5 (mock)` when called with `--version` flag.
+
 ## Quick start
 
 ### Run the server

--- a/client/go/kwkhtmltopdf_client.go
+++ b/client/go/kwkhtmltopdf_client.go
@@ -40,6 +40,9 @@ func do() error {
 	serverURL := os.Getenv("KWKHTMLTOPDF_SERVER_URL")
 	if serverURL == "" {
 		return errors.New("KWKHTMLTOPDF_SERVER_URL not set")
+	} else if serverURL == "MOCK" {
+		os.Stdout.WriteString("wkhtmltopdf 0.12.5 (mock)\n")
+		return nil
 	}
 
 	// detect if last argument is output file, and create it

--- a/client/python/kwkhtmltopdf_client.py
+++ b/client/python/kwkhtmltopdf_client.py
@@ -26,6 +26,13 @@ class ServerError(Error):
 
 def wkhtmltopdf(args):
     url = os.getenv("KWKHTMLTOPDF_SERVER_URL")
+
+    if url == "":
+        raise UsageError("KWKHTMLTOPDF_SERVER_URL not set")
+    elif url == "MOCK":
+        print("wkhtmltopdf 0.12.5 (mock)")
+        return
+
     parts = []
 
     def add_option(option):


### PR DESCRIPTION
Odoo [checks for wkhtmltopdf's version on start](https://github.com/odoo/odoo/blob/12.0/odoo/addons/base/models/ir_actions_report.py#L58).

In a CI context, we don't necessarily want to run the kwkhtmtopdf container.

Provided with `KWKHTMLTOPDF_SERVER_URL=MOCK` environment variable, the client will return "wkhtmltopdf 0.12.5 (mock)" and Odoo will start properly.