### PR TITLE
[IMP] Added Dockerfile for wkhtmltox v0.12.6-1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         tag:
           - "0.12.1.3"
           - "0.12.5"
+          - "0.12.6.1"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
         WKHTMLTOPDF_VERSION:
           - "0.12.1.3"
           - "0.12.5"
+          - "0.12.6.1"
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/Dockerfile-0.12.6.1
+++ b/Dockerfile-0.12.6.1
@@ -1,0 +1,43 @@
+# first stage: build kwkhtmltopdf_server
+
+FROM --platform=linux/amd64 docker.io/golang:1.23.3
+WORKDIR /tmp
+COPY server/kwkhtmltopdf_server.go .
+RUN go build kwkhtmltopdf_server.go
+
+# second stage: server with wkhtmltopdf
+
+FROM --platform=linux/amd64 docker.io/ubuntu:22.04
+
+RUN set -x \
+  && apt update \
+  && apt -y install --no-install-recommends \
+    wget \
+    ca-certificates \
+    fonts-liberation2 \
+    fontconfig \
+    libjpeg-turbo8 \
+    libx11-6 \
+    libxext6 \
+    libxrender1 \
+    xfonts-75dpi \
+    xfonts-base \
+    fonts-lato \
+  && wget -q -O /tmp/wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb \
+  && echo "800eb1c699d07238fee77bf9df1556964f00ffcf /tmp/wkhtmltox.deb" | sha1sum -c - \
+  && dpkg -i /tmp/wkhtmltox.deb \
+  && apt -f install \
+  && apt -y purge wget --autoremove \
+  && apt -y clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm /tmp/wkhtmltox.deb
+
+COPY --from=0 /tmp/kwkhtmltopdf_server /usr/local/bin/
+
+RUN adduser --disabled-password --gecos '' kwkhtmltopdf
+USER kwkhtmltopdf
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+EXPOSE 8080
+CMD ["/usr/local/bin/kwkhtmltopdf_server"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ There are two clients:
 ### Run the server
 
 ```
-$ docker run --rm -p 8080:8080 ghcr.io/acsone/kwkhtmltopdf:0.12.5-latest
+$ docker run --rm -p 8080:8080 ghcr.io/acsone/kwkhtmltopdf:0.12.6.1-latest
 ```
 
 or
@@ -50,6 +50,12 @@ $ go run server/kwkhtmltopdf_server.go
 ```
 
 The server should now listen on http://localhost:8080.
+
+#### Note for Apple Silicon users
+
+The docker image is built for amd64. If you are on Apple Silicon,
+you can use it by disabling the `Use Rosetta for x86_64/amd64 emulation on Apple Silicon` option
+in the Docker Desktop general settings first.
 
 ### Run the client
 


### PR DESCRIPTION
Compared to the other Dockerfiles:
1. I use Ubuntu 20.04 instead of 18.04
2. I changed how the deb file is installed (`dpkg -i` + `apt -f install`)
3. I added the minimum number of dependencies such that rendering is exactly the same as in Odoo.sh
4. I added the --platform flag to avoid pulling the arm64 image which is incompatible with the deb file
5. I Fixed some warning at image build time

I also added the compose file to go along with it.

This Dockerfile is also useable on Apple Silicon. Note that I first tried to make a Dockerfile for arm64, but the pdf rendering was very flacky.